### PR TITLE
Fix bookmark paths to match actual file locations

### DIFF
--- a/bm-files
+++ b/bm-files
@@ -2,13 +2,14 @@
 # Format: alias_name  path
 # Usage: Type 'cfa' to edit aliases, 'cfv' to edit nvim config
 
-# Dotfiles
-cfa  ${XDG_CONFIG_HOME:-$HOME/.config}/shell/aliasrc
+# Dotfiles (symlinked to $HOME)
+cfa  $HOME/.aliases
 cfv  ${XDG_CONFIG_HOME:-$HOME/.config}/nvim/init.vim
-cfz  ${ZDOTDIR:-$HOME}/.zshrc
-cfp  ${ZDOTDIR:-$HOME}/.zprofile
+cfz  $HOME/.zshrc
+cfp  $HOME/.zprofile
 cfg  $HOME/.gitconfig
+cft  $HOME/.tmux.conf
 
-# Bookmarks
-bf   ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-files
-bd   ${XDG_CONFIG_HOME:-$HOME/.config}/shell/bm-dirs
+# Bookmarks (source files in dotfiles repo)
+bf   ${DOTFILES_DIR:-$HOME/.dotfiles}/bm-files
+bd   ${DOTFILES_DIR:-$HOME/.dotfiles}/bm-dirs


### PR DESCRIPTION
## Summary
- Fixed bookmark paths in `bm-files` to point to actual installed locations
- Dotfiles are symlinked to `$HOME/`, not stored at `${DOTFILES_DIR}`
- Added `cft` shortcut for `.tmux.conf` editing

## Changes
**Before (broken):**
```bash
cfa  ${DOTFILES_DIR:-$HOME/.dotfiles}/.aliases  # Wrong - file is at $HOME/.aliases
```

**After (correct):**
```bash
cfa  $HOME/.aliases  # Correct - file is symlinked here
```

## Test Plan
- [ ] After installation, `cfa` opens `~/.aliases`
- [ ] After installation, `cfz` opens `~/.zshrc`
- [ ] After installation, `cfg` opens `~/.gitconfig`
- [ ] Bookmark source files (`bf`, `bd`) still accessible at repo location

Fixes #4