### PR TITLE
Separate user-specific git configuration

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,8 +1,9 @@
 # ABOUTME: Git configuration with delta pager, sensible defaults, and local overrides support
-[user]
-	name = Max Rantil
-	email = rantil@pm.me
-	# signingkey = EDE1D98A8D461DAA7DA5B5BB2C1279AF842D79DF  # Uncomment if using GPG signing
+
+# Include user-specific config (not tracked in git)
+# Copy .gitconfig.local.example to ~/.gitconfig.local and customize with your info
+[include]
+	path = ~/.gitconfig.local
 
 [alias]
 	aa = add --all

--- a/.gitconfig.local.example
+++ b/.gitconfig.local.example
@@ -1,0 +1,14 @@
+# ABOUTME: Template for user-specific git configuration (copy to .gitconfig.local)
+# This file contains user-specific settings that should not be tracked in git
+# Copy this file to ~/.gitconfig.local and customize with your personal information
+
+[user]
+	name = YOUR_NAME
+	email = YOUR_EMAIL
+	# Uncomment and set your GPG key ID if you want to sign commits:
+	# signingkey = YOUR_GPG_KEY_ID
+
+# Optional: Override any settings from the main .gitconfig
+# Example:
+# [core]
+# 	editor = vim

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ autoload/
 *.backup
 *~
 
+# User-specific git configuration
+.gitconfig.local
+
 # OS files
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@ cd ~/.dotfiles
 ./install.sh
 ```
 
+## Post-Install Setup
+
+### Git User Configuration
+
+The dotfiles include a shared `.gitconfig` but require you to set your personal information:
+
+```bash
+# Copy the example template
+cp ~/.dotfiles/.gitconfig.local.example ~/.gitconfig.local
+
+# Edit with your information
+vim ~/.gitconfig.local
+# Set: name, email, and optionally GPG signingkey
+```
+
+This keeps your personal information private and out of the tracked repository.
+
 ## What's Included
 
 - **Zsh** - Vi mode, starship prompt, fzf, auto-detects distro


### PR DESCRIPTION
## Summary
- Removes personal email and name from tracked `.gitconfig` (improves privacy)
- Creates `.gitconfig.local.example` template for user-specific settings
- Updates `.gitconfig` to include local config via `[include]` directive
- Adds `.gitconfig.local` to `.gitignore` to prevent accidental commits
- Documents setup process in README.md under "Post-Install Setup"

## Security Impact
- Prevents email harvesting from public repository
- Reduces targeted phishing risk
- Follows git best practices for shared configuration

## Testing
- All Docker tests passing (5/5 tests, 1.282s startup)
- Pre-commit hooks satisfied (6/6 checks passed)
- Installation creates symlinks correctly
- Git configuration loads properly via include directive

## User Impact
**Required action after install:**
```bash
cp ~/.dotfiles/.gitconfig.local.example ~/.gitconfig.local
vim ~/.gitconfig.local  # Set name, email, optionally GPG key
```

Clear instructions added to README.md Post-Install Setup section.

Fixes #15