### PR TITLE
feat: add lf and fzf navigation keybindings to zshrc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,7 @@ repos:
         description: Lint bash scripts for common issues
         args: ['--severity=warning']
         types: [shell]
+        exclude: '\.zshrc$|\.zsh$'
 
   # =============================================================================
   # MARKDOWN LINTING (for documentation)

--- a/.zshrc
+++ b/.zshrc
@@ -161,6 +161,21 @@ autoload edit-command-line; zle -N edit-command-line
 bindkey '^e' edit-command-line
 bindkey -M vicmd '^e' edit-command-line
 
+# lf file manager integration - Ctrl+O to browse and cd
+lfcd () {
+    tmp="$(mktemp -uq)"
+    trap 'rm -f $tmp >/dev/null 2>&1 && trap - HUP INT QUIT TERM PWR EXIT' HUP INT QUIT TERM PWR EXIT
+    lf -last-dir-path="$tmp" "$@"
+    if [ -f "$tmp" ]; then
+        dir="$(cat "$tmp")"
+        [ -d "$dir" ] && [ "$dir" != "$(pwd)" ] && cd "$dir"
+    fi
+}
+bindkey -s '^o' '^ulfcd\n'
+
+# fzf-based cd to directory containing selected file - Ctrl+F
+bindkey -s '^f' '^ucd "$(dirname "$(fzf)")"\n'
+
 # FZF integration (if installed)
 if [ -f /usr/share/fzf/key-bindings.zsh ]; then
     safe_source /usr/share/fzf/key-bindings.zsh
@@ -228,8 +243,9 @@ ZSH KEYBOARD SHORTCUTS:
   Ctrl+R    - Search backward through history
   Ctrl+S    - Search forward through history
   Ctrl+A    - Jump to beginning of line
-  Ctrl+E    - Jump to end of line
-  Ctrl+E    - Edit command in vim (normal mode)
+  Ctrl+E    - Jump to end of line (or edit in vim in normal mode)
+  Ctrl+O    - Open lf file manager and cd to selected directory
+  Ctrl+F    - Use fzf to select file and cd to its directory
   Delete    - Delete character under cursor
 
 VI MODE INDICATORS:


### PR DESCRIPTION
## Summary
- Add Ctrl+O keybinding for lf file manager integration (browse and cd)
- Add Ctrl+F keybinding for fzf-based directory navigation
- Update help text to document new shortcuts
- Exclude zsh files from shellcheck (not supported)

## Changes
- `.zshrc`: Add lfcd function and keybindings
- `.pre-commit-config.yaml`: Exclude .zsh files from shellcheck
- Updated keybindings_help() documentation

## Testing
- Manual testing: Keybindings work on host machine
- Pre-commit hooks: All passing