### PR TITLE
fix: update starship.toml with cleaner format and proper configuration

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -37,16 +37,16 @@ style = "bold purple"
 [git_status]
 style = "red bold"
 # Accessible text-based indicators (emojis preserved as comments below)
-conflicted = "[CONFLICT$count] "
-ahead = "[↑$count]"
-behind = "[↓$count]"
-diverged = "[↕↑$ahead_count↓$behind_count]"
-untracked = "[?$count]"
-stashed = "[STASH$count]"
-modified = "[M$count]"
-staged = '[+$count](green)'
-renamed = "[R$count]"
-deleted = "[-$count]"
+conflicted = "[CONFLICT${count}] "
+ahead = "[↑${count}]"
+behind = "[↓${count}]"
+diverged = "[↕↑${ahead_count}↓${behind_count}]"
+untracked = "?${count}"
+stashed = "[STASH${count}]"
+modified = "[M${count}]"
+staged = '[+${count}](green)'
+renamed = "[R${count}]"
+deleted = "[-${count}]"
 # Original emoji versions (uncomment to restore):
 # conflicted = "⚔️ "
 # ahead = "⇡${count}"

--- a/starship.toml
+++ b/starship.toml
@@ -1,77 +1,71 @@
 # Starship prompt configuration
-# Install: curl -sS https://starship.rs/install.sh | sh
+command_timeout = 30000
 
+# Clean, informative format
 format = """
-[┌───────────────────>](bold green)
-[│](bold green)$username$hostname$directory$git_branch$git_status
-[└─>](bold green) """
+$username[@](bold green)$hostname in $directory $git_branch$git_status$python
+$character"""
 
+# ===================================
+# USERNAME & HOSTNAME
+# ===================================
+[username]
+show_always = true
+format = "[$user]($style)"
+style_user = "bold yellow"
+style_root = "bold red"
+disabled = false
+
+[hostname]
+ssh_only = false
+format = "[$hostname](bold green)"
+trim_at = "."
+disabled = false
+
+# ===================================
+# DIRECTORY
+# ===================================
 [directory]
 style = "blue bold"
 truncation_length = 3
 truncate_to_repo = true
+fish_style_pwd_dir_length = 1
 
 # ===================================
-# USERNAME - Always show for VM clarity
+# GIT
 # ===================================
-[username]
-show_always = true                    # Show even when not SSH'd in
-format = "[$user]($style)"           # Format: username only
-style_user = "bold yellow"           # Yellow for regular users
-style_root = "bold red"              # Red for root (warning!)
-disabled = false
-
-# ===================================
-# HOSTNAME - Always show for VM clarity
-# ===================================
-[hostname]
-ssh_only = false                     # Show even when not SSH'd in
-format = "[@$hostname](bold green) " # Format: @hostname with space
-trim_at = "."                        # Remove domain suffix
-disabled = false
-
 [git_branch]
-symbol = " "
+symbol = "🌿 "
 style = "bold purple"
 
 [git_status]
 style = "red bold"
-# Accessible text-based indicators (emojis preserved as comments below)
-conflicted = "[CONFLICT${count}] "
-ahead = "[↑${count}]"
-behind = "[↓${count}]"
-diverged = "[↕↑${ahead_count}↓${behind_count}]"
-untracked = "?${count}"
-stashed = "[STASH${count}]"
-modified = "[M${count}]"
-staged = '[+${count}](green)'
-renamed = "[R${count}]"
-deleted = "[-${count}]"
-# Original emoji versions (uncomment to restore):
-# conflicted = "⚔️ "
-# ahead = "⇡${count}"
-# behind = "⇣${count}"
-# diverged = "⇕⇡${ahead_count}⇣${behind_count}"
-# untracked = "🤷 "
-# stashed = "📦"
-# modified = "📝"
-# staged = '[++\($count\)](green)'
-# renamed = "👅"
-# deleted = "🗑"
+format = '([\[$all_status$ahead_behind\]]($style) )'
+conflicted = "CONFLICT"
+ahead = "⇡${count}"
+staged = "+${count}"
+renamed = "R${count}"
+deleted = "-${count}"
 
+# ===================================
+# PROMPT CHARACTER
+# ===================================
 [character]
 success_symbol = "[➜](bold green)"
-error_symbol = "[➜](bold red)"
+error_symbol = "[✗](bold red)"
+
+# ===================================
+# LANGUAGES
+# ===================================
+[python]
+disabled = false
+format = 'via [🐍 $version]($style) '
+
+[rust]
+disabled = true
 
 [nodejs]
 disabled = true
 
-[python]
-disabled = false
-symbol = "PY "
-# symbol = "🐍 "
-
-[rust]
-disabled = false
-symbol = "RS "
-# symbol = "🦀 "
+[kubernetes]
+disabled = true


### PR DESCRIPTION
## Summary
- Simplified prompt format with clean `username@hostname in directory` display
- Added `command_timeout = 30000` for better performance
- Updated git_status with cleaner format string
- Enabled `fish_style_pwd_dir_length` for directory display  
- Updated language symbols (🐍 for Python, 🌿 for git)
- Disabled rust, nodejs, and kubernetes modules
- Changed error symbol from ➜ to ✗ for better clarity

## Changes
This PR includes two commits:
1. Previous commit fixing git_status variable interpolation syntax
2. Complete starship.toml cleanup with the correct configuration

## Test Plan
- [ ] Verify starship prompt displays correctly
- [ ] Check git status formatting
- [ ] Confirm username@hostname always displayed
- [ ] Test prompt performance with command_timeout